### PR TITLE
Fix copyright typo in test

### DIFF
--- a/WorshipSongManagerTests/Unit Tests/SongFormViewModelTests.swift
+++ b/WorshipSongManagerTests/Unit Tests/SongFormViewModelTests.swift
@@ -408,7 +408,7 @@ final class SongFormViewModelTests: XCTestCase {
     
     // MARK: - Public Domain and Copyright Tests
     
-    func testSave_PublicDomain_ClearsRopyright() async throws {
+    func testSave_PublicDomain_ClearsCopyright() async throws {
         // Given
         sut = SongFormViewModel(context: mockContext, mode: .add)
         sut.title = "Test Song"


### PR DESCRIPTION
## Summary
- rename `testSave_PublicDomain_ClearsRopyright` to `testSave_PublicDomain_ClearsCopyright`
- update spelling in comments

## Testing
- `xcodebuild -list` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684c57a946348329b6613f45bfcc80de