### PR TITLE
Add negative tempo validation test

### DIFF
--- a/WorshipSongManagerTests/Unit Tests/SongFormViewModelTests.swift
+++ b/WorshipSongManagerTests/Unit Tests/SongFormViewModelTests.swift
@@ -197,6 +197,21 @@ final class SongFormViewModelTests: XCTestCase {
         XCTAssertFalse(result)
         XCTAssertTrue(sut.validationErrors.contains("Tempo seems too slow (minimum 40 BPM recommended)"))
     }
+
+    func testValidation_NegativeTempo_ShowsError() async throws {
+        // Given
+        sut = SongFormViewModel(context: mockContext, mode: .add)
+        sut.title = "Test Song"
+        sut.key = "C"
+        sut.tempo = "-10"
+
+        // When
+        let result = await sut.save()
+
+        // Then
+        XCTAssertFalse(result)
+        XCTAssertTrue(sut.validationErrors.contains("Tempo seems too slow (minimum 40 BPM recommended)"))
+    }
     
     func testValidation_TooFastTempo_ShowsWarning() async throws {
         // Given


### PR DESCRIPTION
## Summary
- expand SongFormViewModelTests with a case for negative tempo

## Testing
- `xcodebuild test -project WorshipSongManager.xcodeproj -scheme WorshipSongManager -destination 'platform=iOS Simulator,name=iPhone 14'`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_684c57fbba1883299a4b127c71bf002a